### PR TITLE
Add badge with link to Wikipedia 'Flow Cytometry' page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![wiki:flow-cytometry](https://img.shields.io/badge/Wikipedia-Flow%20Cytometry-blue.svg)](https://en.wikipedia.org/wiki/Flow_cytometry)
+
 Notes about FCS gating
 ================
 


### PR DESCRIPTION
May be helpful for curious stumblers?